### PR TITLE
Adds GFDL content license

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,9 @@
     <div class="container">
         <div class="row">
             <div class="col-sm-6">
-                <i class="fa fa-copyright"></i> BioPerl 2017
+                <i class="fa fa-copyright"></i> BioPerl 2017.
+                Content available under the <a href="https://www.gnu.org/licenses/old-licenses/fdl-1.2.html">GNU Free Documentation License 1.2</a>
+                except where noted otherwise.
             </div>
             <div class="col-sm-6">
                 <!--


### PR DESCRIPTION
This corrects an oversight from the migration from MediaWiki in 2017. [GFDL 1.2](https://www.gnu.org/licenses/old-licenses/fdl-1.2.html) had been the license previously used on the wiki, so this is continuing that here: <https://web.archive.org/web/20151102182958/http://www.bioperl.org/wiki/Main_Page>

Note that the [latest version of the GFDL is currently 1.3](https://www.gnu.org/copyleft/fdl.html), not 1.2. We could change to that, though I'm not sure whether we'd need to obtain the approval of individual authors (I think not – there wasn't any individual author holding copyright in any particular part of the wiki).

See biopython/biopython.github.io#117 for the same issue for the Biopython wiki.

Fixes #42.